### PR TITLE
Fix instructions

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -13,7 +13,7 @@ const providers = [
 Add trait and casts to the model:
 ```js
 class User {
-  static super () {
+  static boot () {
     super.boot()
     
       // Add the trait and casts to a model


### PR DESCRIPTION
There is a mistake in instructions.md, the function is called "boot" and not "super".